### PR TITLE
Updated Multiplexer Functions

### DIFF
--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -105,6 +105,7 @@ void Accessory::switchMultiplexer(){
 void Accessory::switchMultiplexer(uint8_t iic, uint8_t sw){
     if(sw >= 8) return;
     
+    if(TWCR == 0){ myWire.begin(); } // Start I2C if it's not running
     sendMultiSwitch(iic, sw);
 }
 

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -84,8 +84,6 @@ ControllerType Accessory::identifyController() {
     return Unknown;
 }
 
-void Accessory::addMultiplexer(uint8_t sw){
-    addMultiplexer(0x70, sw);
 }
 
 void Accessory::addMultiplexer(uint8_t iic, uint8_t sw){

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -84,6 +84,10 @@ ControllerType Accessory::identifyController() {
     return Unknown;
 }
 
+void Accessory::sendMultiSwitch(uint8_t iic, uint8_t sw){
+    myWire.beginTransmission(iic);
+    myWire.write(1 << sw);
+    myWire.endTransmission();
 }
 
 void Accessory::addMultiplexer(uint8_t iic, uint8_t sw){
@@ -95,15 +99,13 @@ void Accessory::addMultiplexer(uint8_t iic, uint8_t sw){
 
 void Accessory::switchMultiplexer(){
     if(_multiplexI2C == 0) return; // No multiplexer set
-    switchMultiplexer(_multiplexI2C, _multiplexSwitch);
+    sendMultiSwitch(_multiplexI2C, _multiplexSwitch);
 }
 
 void Accessory::switchMultiplexer(uint8_t iic, uint8_t sw){
     if(sw >= 8) return;
     
-    myWire.beginTransmission(iic);
-    myWire.write(1 << sw);
-    myWire.endTransmission();
+    sendMultiSwitch(iic, sw);
 }
 
 /*

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -133,7 +133,7 @@ protected:
     void _burstWriteWithAddress(uint8_t addr,uint8_t* arr,uint8_t size);
 
 
-
+    static void sendMultiSwitch(uint8_t iic, uint8_t sw);
 private:
 
 

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -132,10 +132,8 @@ protected:
     void _writeRegister(uint8_t reg, uint8_t value);
     void _burstWriteWithAddress(uint8_t addr,uint8_t* arr,uint8_t size);
 
-
-    static void sendMultiSwitch(uint8_t iic, uint8_t sw);
 private:
-
+    static void sendMultiSwitch(uint8_t iic, uint8_t sw);
 
     // Controller Register Transactions
 

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -55,7 +55,6 @@ public:
 
     void enableEncryption(bool enc);
 
-    void addMultiplexer(uint8_t sw);
     void addMultiplexer(uint8_t iic, uint8_t sw);
     void switchMultiplexer();
     static void switchMultiplexer(uint8_t iic, uint8_t sw);


### PR DESCRIPTION
Some behind-the-scenes changes for the multiplexer functions:
* I separated the actual I2C calls into a helper function that can be called by either the static or member version of the function, which streamlines things.
* The static 'switch' function will now call the `Wire.begin()` method if the bus hasn't been started. This is necessary for single controllers using a multiplexer.
* I also removed the `addMultiplexer` function with a default I2C address. Can always add it back later if need-be.