### PR TITLE
Nunchuck button 'get' prefix & Drum switch syntax

### DIFF
--- a/src/Drums.cpp
+++ b/src/Drums.cpp
@@ -176,36 +176,29 @@ void Drums::printInputs(Stream& stream) {
 	if (getSoftnessDataFlag()){
 		switch(getSoftnessDataFor()){
 			case 27:
-			{
 				stream.print("bass pedal:\t");
 				stream.print(getSoftness());
-			break;
-			}
-			case 25:{
+				break;
+			case 25:
 				stream.print("red drum:\t");
 				stream.print(getSoftness());
-			break;
-			}
-			case 17:{
+				break;
+			case 17:
 				stream.print("yellow drum:\t");
 				stream.print(getSoftness());
-			break;
-			}
-			case 15:{
+				break;
+			case 15:
 				stream.print("blue drumm:\t");
 				stream.print(getSoftness());
-			break;
-			}
-			case 14:{
+				break;
+			case 14:
 				stream.print("orange drum:\t");
 				stream.print(getSoftness());
-			break;
-			}
-			case 18:{
+				break;
+			case 18:
 				stream.print("green drum:\t");
 				stream.print(getSoftness());
-			break;
-			}
+				break;
 		}
 		if (getHighHatDataFlag()){
 			stream.print("high hat:\t");

--- a/src/Nunchuck.cpp
+++ b/src/Nunchuck.cpp
@@ -25,10 +25,10 @@ int Nunchuck::getAccelY() {
 int Nunchuck::getAccelZ() {
 	return decodeInt(accelZBytes);
 }
-boolean Nunchuck::checkButtonC() {
+boolean Nunchuck::getButtonC() {
 	return decodeBit(buttonCBits);
 }
-boolean Nunchuck::checkButtonZ() {
+boolean Nunchuck::getButtonZ() {
 	return decodeBit(buttonZBits);
 }
 
@@ -42,11 +42,11 @@ void Nunchuck::printInputs(Stream& stream) {
 
 	stream.print(st);
 
-	if (checkButtonC())
+	if (getButtonC())
 		stream.print("C");
 	else
 		stream.print("-");
-	if (checkButtonZ())
+	if (getButtonZ())
 		stream.print("Z");
 	else
 		stream.print("-");
@@ -95,7 +95,7 @@ void Nunchuck::pitch::printMap(Stream& stream) {
 
 unsigned int Nunchuck::buttonC::mapVar() {
 	Nunchuck* c = (Nunchuck*)controller;
-	return (c->checkButtonC()) ? servoMax:servoZero;
+	return (c->getButtonC()) ? servoMax:servoZero;
 }
 
 void Nunchuck::buttonC::printMap(Stream& stream) {
@@ -105,7 +105,7 @@ void Nunchuck::buttonC::printMap(Stream& stream) {
 
 unsigned int Nunchuck::buttonZ::mapVar() {
 	Nunchuck* c = (Nunchuck*)controller;
-	return (c->checkButtonZ()) ? servoMax:servoZero;
+	return (c->getButtonZ()) ? servoMax:servoZero;
 }
 
 void Nunchuck::buttonZ::printMap(Stream& stream) {

--- a/src/Nunchuck.h
+++ b/src/Nunchuck.h
@@ -28,8 +28,8 @@ public:
 	int getAccelY();
 	int getAccelZ();
 
-	boolean checkButtonC();
-	boolean checkButtonZ();
+	boolean getButtonC();
+	boolean getButtonZ();
 
 	class joyX : public Accessory::Mapping
 	{


### PR DESCRIPTION
Two small miscellaneous updates:
- The Nunchuk button checking functions were renamed from a `check` prefix to a `get` prefix, which matches all of the other user-facing functions throughout the library.
- The brackets in the Drums `printInputs` switch case were removed, as they aren't part of the case syntax. I indented the breaks as well.