### PR TITLE
Renamed unknown Enum due to conflict with Ethernet library.

### DIFF
--- a/examples/WiiAccessory/WiiAccessory.ino
+++ b/examples/WiiAccessory/WiiAccessory.ino
@@ -5,7 +5,7 @@ Accessory nunchuck1;
 void setup() {
 	Serial.begin(115200);
 	nunchuck1.begin();
-	if (nunchuck1.type == Unknown) {
+	if (nunchuck1.type == UnknownChuck) {
 		/** If the device isn't auto-detected, set the type explicatly
 		 * 	NUNCHUCK,
 		 WIICLASSIC,

--- a/examples/WiiAccessoryMultiplex/WiiAccessoryMultiplex.ino
+++ b/examples/WiiAccessoryMultiplex/WiiAccessoryMultiplex.ino
@@ -19,10 +19,10 @@ void setup() {
 	 DrawsomeTablet,
 	 Turntable
 	 */
-	if (nunchuck1.type == Unknown) {
+	if (nunchuck1.type == UnknownChuck) {
 		nunchuck1.type = NUNCHUCK;
 	}
-	if (nunchuck2.type == Unknown) {
+	if (nunchuck2.type == UnknownChuck) {
 		nunchuck2.type = NUNCHUCK;
 	}
 }

--- a/examples/WiiServoMap/WiiServoMap.ino
+++ b/examples/WiiServoMap/WiiServoMap.ino
@@ -14,7 +14,7 @@ void setup() {
 	Serial.begin(115200);
 	Serial.println("Loading controller...");
 	nunchuck1.begin();
-	if (nunchuck1.type == Unknown) {
+	if (nunchuck1.type == UnknownChuck) {
 		/** If the device isn't auto-detected, set the type explicatly
 		 * 	
 		 NUNCHUCK,

--- a/keywords.txt
+++ b/keywords.txt
@@ -211,4 +211,4 @@ GuitarHeroController	LITERAL1
 GuitarHeroWorldTourDrums	LITERAL1
 DrumController	LITERAL1
 DrawsomeTablet	LITERAL1
-Unknown	LITERAL1
+UnknownChuck	LITERAL1

--- a/src/Accessory.cpp
+++ b/src/Accessory.cpp
@@ -64,7 +64,7 @@ ControllerType Accessory::identifyController() {
 						if (_dataarray[5] == 0x13)
 							return DrawsomeTablet; // Drawsome Tablet
 
-	return Unknown;
+	return UnknownChuck;
 }
 
 void Accessory::sendMultiSwitch(uint8_t iic, uint8_t sw) {

--- a/src/Accessory.h
+++ b/src/Accessory.h
@@ -43,7 +43,7 @@
 #define dataArraySize 6
 
 typedef enum _controllertype {
-	Unknown,
+	UnknownChuck,
 	NUNCHUCK,
 	WIICLASSIC,
 	GuitarHeroController,


### PR DESCRIPTION
In the current implementation, the `Unknown` declaration conflicts with the standard Ethernet Arduino library:
```
In file included from libraries/WiiChuck/src/WiiChuck.h:4:0,
                 from sketch/sketch.ino:4:
libraries/WiiChuck/src/Accessory.h:46:2: error: redeclaration of 'Unknown'
  Unknown,
  ^~~~~~~
In file included from sketch/sketch.ino:1:0:
libraries/Ethernet/src/Ethernet.h:57:2: note: previous declaration 'EthernetLinkStatus Unknown'
  Unknown,
  ^~~~~~~
Multiple libraries were found for "Ethernet.h"
  Used: libraries/Ethernet
  Not used: .arduino15/libraries/Ethernet
exit status 1

Compilation error: exit status 1
```

To solve this I have renamed the declaration throughout to `UnknownChuck` to avoid this conflict, seems a but janky but it seems to work, if anyone else knows a more elegant way... Could use `enum class` but probably would need more changes.

Not been elaborately tested.